### PR TITLE
fix: resolve all CI failures after upstream 3.5.0 sync

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -69,7 +69,7 @@ jobs:
     name: Python Tests
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           # Default to test without coverage tracking on older python versions.
           # This saves time, as testing without coverage tracking is faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,7 @@ changes.
 
 If you plan on working with a particular dbt plugin, you will need
 to ensure your python version is high enough to support it. For example,
-the instructions below use `python3.12`, and we support as low as `python3.8`
-but if you are working with `dbt-snowflake` 1.9.0 you will need python at least 3.9.
+the instructions below use `python3.13`, and we support as low as `python3.9`.
 
 The simplest way to set up a development environment is to use `tox`.
 
@@ -94,8 +93,8 @@ First ensure that you have tox installed:
 ```shell
 python3.12 -m pip install -U tox
 ```
-**IMPORTANT:** Python 3.8 is the minimum version we support. Feel free
-to test on anything between `python3.8` and `python3.13`.
+**IMPORTANT:** Python 3.9 is the minimum version we support. Feel free
+to test on anything between `python3.9` and `python3.13`.
 
 Note: Unfortunately tox does not currently support setting just a minimum
 Python version (though this may be be coming in tox 4!).
@@ -114,7 +113,7 @@ source .venv/bin/activate
 ```
 (The `dbt180` environment is a good default choice.
 However any version can be installed by replacing `dbt180` with
-`py`, `py38` through `py313`, `dbt140` through `dbt190`, etc.
+`py`, `py39` through `py313`, `dbt140` through `dbt190`, etc.
 `py` defaults to the python version that was used to install tox.
 To be able to run all tests including the dbt templater,
 choose one of the dbt environments.)
@@ -175,19 +174,19 @@ tox
 This will build and test for several Python versions, and also lint the project.
 Practically on a day-to-day basis, you might only want to lint and test for one
 Python version, so you can always specify a particular environment. For example,
-if you are developing in Python 3.8 you might call...
+if you are developing in Python 3.9 you might call...
 
 ```shell
-tox -e generate-fixture-yml,py38,linting,mypy
+tox -e generate-fixture-yml,py39,linting,mypy
 ```
 
 ...or if you also want to see the coverage reporting...
 
 ```shell
-tox -e generate-fixture-yml,cov-init,py38,cov-report,linting,mypy
+tox -e generate-fixture-yml,cov-init,py39,cov-report,linting,mypy
 ```
 
-> NB: The `cov-init` task clears the previous test results, the `py38` environment
+> NB: The `cov-init` task clears the previous test results, the `py39` environment
 > generates the results for tests in that Python version and the `cov-report`
 > environment reports those results out to you (excluding dbt).
 
@@ -196,13 +195,13 @@ faster while working on an issue, before running full tests at the end.
 For example, you can run specific tests by making use of the `-k` option in `pytest`:
 
 ```
-tox -e py38 -- -k AL02 test
+tox -e py39 -- -k AL02 test
 ```
 
 Alternatively, you can also run tests from a specific directory or file only:
 ```
-tox -e py38 -- test/cli
-tox -e py38 -- test/cli/commands_test.py
+tox -e py39 -- test/cli
+tox -e py39 -- test/cli/commands_test.py
 ```
 
 You can also manually test your updated code against a SQL file via:
@@ -276,7 +275,7 @@ We recommend using https://postgresapp.com/.
 To run the dbt-related tests you will have to explicitly include these tests:
 
 ```shell
-tox -e cov-init,dbt018-py38,cov-report-dbt -- plugins/sqlfluff-templater-dbt
+tox -e cov-init,dbt019-py39,cov-report-dbt -- plugins/sqlfluff-templater-dbt
 ```
 
 For more information on adding and running test cases see the [Parser Test README](test/fixtures/dialects/README.md) and the [Rules Test README](test/fixtures/rules/std_rule_cases/README.md).

--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -1025,7 +1025,7 @@ For example if you're adding or modifying
 
 .. code-block:: bash
 
-   tox -e py38 -- -s test/dialects/dialects_test.py -k hive-select_interval.sql
+   tox -e py39 -- -s test/dialects/dialects_test.py -k hive-select_interval.sql
 
 The :code:`-s` flag for pytest enables printing of post-parse structure,
 which allows you to quickly check that each query element is typed
@@ -1045,13 +1045,13 @@ The following command runs just the dialect tests, for **all** dialects:
 
 .. code-block:: bash
 
-   tox -e py38 -- test/dialects/dialects_test.py
+   tox -e py39 -- test/dialects/dialects_test.py
 
 The following command runs just the dialect tests, for **a specific** dialect:
 
 .. code-block:: bash
 
-   tox -e py38 -- test/dialects/dialects_test.py -k ansi
+   tox -e py39 -- test/dialects/dialects_test.py -k ansi
 
 Or, if making a dialect change to fix a rule that is incorrectly flagging,
 you can just run the tests for that one rule, for example to run the
@@ -1059,7 +1059,7 @@ you can just run the tests for that one rule, for example to run the
 
 .. code-block:: bash
 
-   tox -e py38 -- -k LT01 test
+   tox -e py39 -- -k LT01 test
 
 Final checks before committing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/guides/contributing/git.rst
+++ b/docs/source/guides/contributing/git.rst
@@ -476,7 +476,7 @@ So, when you're ready to make your first changes, do the following:
 
 5. If making code changes to the website then test them - follow instructions
    in `CONTRIBUTING.md`_ to set up the environment and then use
-   :code:`tox -e generate-fixture-yml,cov-init,py38,cov-report,linting` to
+   :code:`tox -e generate-fixture-yml,cov-init,py39,cov-report,linting` to
    run most of the tests.
 
 6. Add any new files you added in this change that you want tracked in
@@ -678,7 +678,7 @@ to open a pull request back to the original repo to accept your code into
 SQLFluff:
 
 1. Merge in any changes that happened to SQLFluff code since you branches (see above).
-2. Run all the automated tests :code:`tox -e generate-fixture-yml,cov-init,py38,cov-report,linting`.
+2. Run all the automated tests :code:`tox -e generate-fixture-yml,cov-init,py39,cov-report,linting`.
 3. Make sure all your changes are pushed to GitHub.
 4. Open a pull request in GitHub.
 5. If the pull request closes an issue then you can add "Closes #123" or

--- a/plugins/sqlfluff-plugin-example/pyproject.toml
+++ b/plugins/sqlfluff-plugin-example/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 # Change this name in your plugin, e.g. company name or plugin purpose.
 name = "sqlfluff-plugin-example"
 version = "1.0.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "sqlfluff>=0.4.0"
+    "sqlfluff>=3.1.0"
 ]
 
 [project.entry-points.sqlfluff]

--- a/plugins/sqlfluff-plugin-example/pyproject.toml
+++ b/plugins/sqlfluff-plugin-example/pyproject.toml
@@ -8,7 +8,7 @@ name = "sqlfluff-plugin-example"
 version = "1.0.0"
 requires-python = ">=3.9"
 dependencies = [
-    "sqlfluff>=3.1.0"
+    "collate-sqlfluff>=3.1.0"
 ]
 
 [project.entry-points.sqlfluff]

--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -79,7 +78,6 @@ dependencies = [
     "colorama>=0.3",
     # Used for diffcover plugin
     "diff-cover>=2.5.0",
-    "importlib_resources; python_version < '3.9'",
     "Jinja2",
     # Used for .sqlfluffignore
     "pathspec",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,9 @@
 flake8
 flake8-docstrings
 pydocstyle!=6.2.0, !=6.2.1  # See: https://github.com/PyCQA/pydocstyle/issues/618
-black>=22.1.0
+# Pin black to 25.1.0 — upstream 3.5.0 was tested with this version.
+# Unpinned black>=22.1.0 resolves to 26.x which reformats upstream code.
+black==25.1.0
 flake8-black>=0.3.7
 ruff
 import-linter

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -25,7 +25,7 @@ if sys.version_info[0] < 3:
 # Check minor python version
 elif sys.version_info[1] < 8:
     raise Exception(
-        "Sqlfluff %s only supports Python 3.8 and beyond. "
+        "Sqlfluff %s only supports Python 3.9 and beyond. "
         "Use an earlier version of sqlfluff or a later version of Python" % __version__
     )
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -149,7 +149,7 @@ def common_options(f: Callable) -> Callable:
 
     These are applied to all of the cli commands.
     """
-    f = click.version_option()(f)
+    f = click.version_option(package_name="collate-sqlfluff")(f)
     f = click.option(
         "-v",
         "--verbose",
@@ -476,7 +476,7 @@ def get_linter_and_formatter(
    sqlfluff parse --dialect duckdb --templater jinja path/my_query.sql\n\n
 """,
 )
-@click.version_option()
+@click.version_option(package_name="collate-sqlfluff")
 def cli() -> None:
     """SQLFluff is a modular SQL linter for humans."""  # noqa D403
 

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -12,6 +12,7 @@ import logging
 import os
 import os.path
 import sys
+import threading
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
@@ -34,6 +35,10 @@ from sqlfluff.core.types import ConfigMappingType
 
 # Instantiate the config logger
 config_logger = logging.getLogger("sqlfluff.config")
+
+# Lock for thread-safe environment variable manipulation in
+# _get_user_config_dir_path. Needed for free-threaded Python (3.14+).
+_env_lock = threading.Lock()
 
 global_loader = None
 """:obj:`ConfigLoader`: A variable to hold the single module loader when loaded.
@@ -74,9 +79,19 @@ def _get_user_config_dir_path(sys_platform: str) -> str:
         # Technically we could just delegate to the generic `user_config_dir`
         # method, but for testing it's convenient to explicitly call the macos
         # methods here.
-        return platformdirs.macos.MacOS(
-            appname=appname, appauthor=appauthor
-        ).user_config_dir
+        # NOTE: On platformdirs >= 4.6.0, MacOS also respects XDG_CONFIG_HOME.
+        # Temporarily unset it so we get the native macOS path when the XDG
+        # path doesn't exist. Use a lock for thread safety (free-threaded
+        # Python 3.14+).
+        with _env_lock:
+            xdg_config_home = os.environ.pop("XDG_CONFIG_HOME", None)
+            try:
+                return platformdirs.macos.MacOS(
+                    appname=appname, appauthor=appauthor
+                ).user_config_dir
+            finally:
+                if xdg_config_home is not None:
+                    os.environ["XDG_CONFIG_HOME"] = xdg_config_home
     # NOTE: We could delegate to the generic `user_config_dir` method here,
     # but for testing it's convenient to explicitly call the linux methods.
     elif sys_platform == "linux":

--- a/src/sqlfluff/core/plugin/host.py
+++ b/src/sqlfluff/core/plugin/host.py
@@ -36,7 +36,7 @@ def _get_sqlfluff_version() -> str:
     NOTE: At the stage of loading plugins, SQLFluff isn't fully
     initialised and so we can't use the normal methods.
     """
-    return importlib.metadata.version("sqlfluff")
+    return importlib.metadata.version("collate-sqlfluff")
 
 
 def _discover_plugins() -> Iterator[tuple[importlib.metadata.EntryPoint, str, str]]:

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4854,12 +4854,7 @@ class DynamicTableOptionsSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
                 optional=True,
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-                optional=True,
-            ),
+            Ref("CommentEqualsClauseSegment", optional=True),
             Sequence(
                 Ref.keyword("WITH", optional=True),
                 "ROW",

--- a/test/fixtures/dialects/snowflake/create_table.yml
+++ b/test/fixtures/dialects/snowflake/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 384fa3005daf2b1668eacdc1f9eed2617bd927dbdfd8729e28a4c29b78052c70
+_hash: d3453e7f6bd9b255780295b9cb48d972adf7a4cb0ab8080e438ee4b9c3c05604
 file:
 - statement:
     create_table_statement:
@@ -330,10 +330,11 @@ file:
           quoted_literal: "'a column comment'"
         end_bracket: )
     - dynamic_table_options:
-        keyword: comment
-        comparison_operator:
-          raw_comparison_operator: '='
-        quoted_literal: "'a table comment'"
+        comment_equals_clause:
+          keyword: comment
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'a table comment'"
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -2216,10 +2217,11 @@ file:
           raw_comparison_operator: '='
       - boolean_literal: 'FALSE'
     - dynamic_table_options:
-        keyword: COMMENT
-        comparison_operator:
-          raw_comparison_operator: '='
-        quoted_literal: "'<string_literal>'"
+        comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<string_literal>'"
         tag_bracketed_equals:
         - keyword: WITH
         - keyword: TAG
@@ -2265,10 +2267,11 @@ file:
           raw_comparison_operator: '='
       - boolean_literal: 'false'
     - dynamic_table_options:
-        keyword: COMMENT
-        comparison_operator:
-          raw_comparison_operator: '='
-        quoted_literal: "'<string_literal>'"
+        comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<string_literal>'"
 - statement_terminator: ;
 - statement:
     create_table_statement:

--- a/test/fixtures/dialects/snowflake/create_table_comments.yml
+++ b/test/fixtures/dialects/snowflake/create_table_comments.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e535be05b5ed1e974162bae91206e80afb584f9aadfcb5b2a57161519cc58bc9
+_hash: 5591855171a2675fc3292d806b4e4b0a79e62392754cfdeff1323fa7b903dc2d
 file:
   statement:
     create_table_statement:
@@ -19,8 +19,9 @@ file:
             data_type_identifier: INTEGER
         end_bracket: )
     - dynamic_table_options:
-        keyword: COMMENT
-        comparison_operator:
-          raw_comparison_operator: '='
-        quoted_literal: "'1'"
+        comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'1'"
   statement_terminator: ;

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312,313}, dbt{140,150,160,170,180,190}, cov-report, mypy, mypyc, winpy, dbt{150,180,190}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{39,310,311,312,313}, dbt{140,150,160,170,180,190}, cov-report, mypy, mypyc, winpy, dbt{150,180,190}-winpy, yamllint
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{140,150,160,170,180,190}: -r "{toxinidir}/constraints/{envname}.txt"
+    dbt{140,150,160,170,180,190}: -r constraints/{envname}.txt
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
@@ -38,7 +38,7 @@ commands =
     # the python version is not specified and instead the "py" or "winpy"
     # environment is invoked. Leaving the trailing comma ensures that this
     # environment still installs the relevant plugins.
-    {py,winpy}{38,39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
+    {py,winpy}{39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
     # Clean up from previous tests
     python "{toxinidir}/util.py" clean-tests
     # Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -124,15 +124,15 @@ commands =
 skip_install = true
 changedir = src
 commands =
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.api
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.cli
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.config
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.dialects
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.helpers
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.linter
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.parser.grammar
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.plugin
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.utils.reflow
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.api
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.cli
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.config
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.dialects
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.helpers
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.linter
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.parser.grammar
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.plugin
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.utils.reflow
 
 [testenv:build-dist]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -203,13 +203,13 @@ source =
     # Local path
     src/
     # These are the Github likely source paths
-    D:\a\sqlfluff\sqlfluff\src\
-    D:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
+    D:\a\collate-sqlfluff\collate-sqlfluff\src\
+    D:\a\collate-sqlfluff\collate-sqlfluff\.tox\winpy\Lib\site-packages\
     # Github Actions are now using C:
-    C:\a\sqlfluff\sqlfluff\src\
-    C:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
-    /home/runner/work/sqlfluff/sqlfluff/src/
-    /home/runner/work/sqlfluff/sqlfluff/.tox/*/lib/*/site-packages/
+    C:\a\collate-sqlfluff\collate-sqlfluff\src\
+    C:\a\collate-sqlfluff\collate-sqlfluff\.tox\winpy\Lib\site-packages\
+    /home/runner/work/collate-sqlfluff/collate-sqlfluff/src/
+    /home/runner/work/collate-sqlfluff/collate-sqlfluff/.tox/*/lib/*/site-packages/
 dbt_templater =
     plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/
     .tox/*/lib/*/site-packages/sqlfluff_templater_dbt/


### PR DESCRIPTION
### Brief summary of the change made

**Revert stale Python 3.8 artifacts:**
- Revert of 9a98b9c3 ("Revert Drop support for Python 3.8") which predated
  the 3.5.0 sync, leaving contradictory 3.8 references that conflict with
  `requires-python >= 3.9`

**Cherry-pick upstream post-3.5.0 fixes:**
- sqlfluff/sqlfluff#7698 — add `--no-warn-unused-configs` to mypyc commands
  (mypy 1.20.0 treats unused overrides as hard error)
- sqlfluff/sqlfluff#7656 — support platformdirs >= 4.6.0 macOS XDG behavior
  (fixes config path test failures on Linux CI)

**Fork-specific fixes:**
- Fix package name references (`sqlfluff` → `collate-sqlfluff`) in host.py,
  commands.py, and plugin-example dependency
- Fix coverage paths in tox.ini for `collate-sqlfluff` repo name
- Pin `black==25.1.0` (upstream moved to ruff-only after 3.5.0, unpinned
  black resolves to 26.x which reformats upstream code)
- Use `CommentEqualsClauseSegment` in `DynamicTableOptionsSegment` so LT05's
  `ignore_comment_clauses` works on Snowflake COMMENT clauses (fixes rules_suite)

### Are there any other side effects of this change that we should be aware of?

- Python 3.8 is no longer tested (aligns with upstream 3.5.0 and `requires-python >= 3.9`)
- Snowflake COMMENT inside dynamic_table_options is now typed as `comment_equals_clause`
  (parse tree structure change only — same tokens, no behavior change, no impact on sqllineage)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.
- [x] `.sql`/`.yml` parser test cases regenerated for Snowflake dialect
- [x] All CI checks verified locally (rules_suite, parse_suite, fix_suite, mypyc, black, mypy, yamllint)
